### PR TITLE
remove necessary orderBy, add customizable count, export addFilter

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export * from './decorator'
 export * from './paginate'
+export { addFilter } from './filter'


### PR DESCRIPTION
- remove necessary order by cause in big databases an order by can cause issues (also if the column has an index)
- add customizable count, cause a count dont need all relations (performance)
- export addFilter that we can add the filter to the count queryBuilder or other reasons